### PR TITLE
Show "do not record" icon on schedule calendar view

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -136,7 +136,8 @@ export default {
 					end: moment.tz(session.end, this.currentTimezone),
 					speakers: session.speakers?.map(s => this.speakersLookup[s]),
 					track: this.tracksLookup[session.track],
-					room: this.roomsLookup[session.room]
+					room: this.roomsLookup[session.room],
+					do_not_record: session.do_not_record
 				})
 			}
 			sessions.sort((a, b) => a.start.diff(b.start))

--- a/src/components/Session.vue
+++ b/src/components/Session.vue
@@ -18,6 +18,12 @@ a.c-linear-schedule-session(:class="{faved}", :style="style", :href="link", @cli
 		.bottom-info
 			.track(v-if="session.track") {{ getLocalizedString(session.track.name) }}
 			.room(v-if="showRoom && session.room") {{ getLocalizedString(session.room.name) }}
+	
+		svg.do_not_record(v-if="session.do_not_record", viewBox="0 -1 24 24", width="40px", height="30px", fill="none", xmlns="http://www.w3.org/2000/svg")
+			path(d="M1.29292 20.2929C0.902398 20.6834 0.902398 21.3166 1.29292 21.7071C1.68345 22.0976 2.31661 22.0976 2.70714 21.7071L22.7071 1.70711C23.0977 1.31658 23.0977 0.68342 22.7071 0.29289C22.3166 -0.097631 21.6834 -0.097631 21.2929 0.29289L20.2975 1.28829C20.296 1.28982 20.2944 1.29135 20.2929 1.29289L2.29289 19.2929C2.29136 19.2944 2.28984 19.296 2.28832 19.2975L1.29292 20.2929z", fill="#758CA3")
+			path(d="M15 3C15.2339 3 15.4615 3.02676 15.68 3.07739L13.7574 5H3C2.44772 5 2 5.44771 2 6V16C2 16.2142 2.06734 16.4126 2.182 16.5754L0.87868 17.8787C0.839067 17.9183 0.800794 17.9587 0.76386 18C0.28884 17.4692 0 16.7683 0 16V6C0 4.34314 1.34315 3 3 3H15z", fill="#758CA3")
+			path(d="M10.2426 17H15C15.5523 17 16 16.5523 16 16V14.0233C15.9996 14.0079 15.9996 13.9924 16 13.9769V11.2426L18 9.2426V13.2792L22 14.6126V7.38742L18.7828 8.45982L21.9451 5.29754L22.6838 5.05132C23.3313 4.83547 24 5.31744 24 6V16C24 16.6826 23.3313 17.1645 22.6838 16.9487L18 15.3874V16C18 17.6569 16.6569 19 15 19H8.24264L10.2426 17z", fill="#758CA3")
+
 	bunt-icon-button.btn-fav-container(@click.prevent.stop="faved ? $emit('unfav', session.id) : $emit('fav', session.id)")
 		svg.star(viewBox="0 0 24 24")
 			path(d="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z")
@@ -232,4 +238,8 @@ export default {
 			display: inline-flex
 	// +below('m')
 	// 	min-width: 0
+	.do_not_record
+		position: absolute
+		top: 3px
+		right: 80px
 </style>


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a new feature that displays a 'do not record' icon on the schedule calendar view for sessions that are marked as 'do not record'.

- **New Features**:
    - Added a 'do not record' icon to the schedule calendar view for sessions marked as 'do not record'.

<!-- Generated by sourcery-ai[bot]: end summary -->