### PR TITLE
Remove number icon indicating popularity from schedule calendar view

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -18,7 +18,6 @@
 					path(d="m344.75 463.61h-117.92c-6.6289 0-11.84 5.2109-11.84 11.84s5.2109 11.84 11.84 11.84h117.92c5.2109 17.523 21.312 30.309 40.727 30.309 18.941 0 35.52-12.785 40.254-30.309h99.926c6.6289 0 11.84-5.2109 11.84-11.84s-5.2109-11.84-11.84-11.84h-99.926c-5.2109-17.523-21.312-30.309-40.254-30.309-19.418 0-35.52 12.785-40.727 30.309zm58.723 11.84c0 10.418-8.5234 18.469-18.469 18.469s-18.469-8.0508-18.469-18.469 8.5234-18.469 18.469-18.469 18.469 8.0508 18.469 18.469z")
 				template Filter
 				template(v-if="filteredTracks.length") ({{ filteredTracks.length }})
-			bunt-select(v-if="!showGrid", style="margin-left: 0px", name="sort", :options="sortOptions", v-model="selectedSort")
 			bunt-button.fav-toggle(v-if="favs.length", @click="onlyFavs = !onlyFavs; if (onlyFavs) resetFilteredTracks()", :class="onlyFavs ? ['active'] : []")
 				svg#star(viewBox="0 0 24 24")
 					polygon(
@@ -119,7 +118,8 @@ export default {
 			return this.schedule ? Math.min(this.scrollParentWidth, 78 + this.schedule.rooms.length * 650) : this.scrollParentWidth
 		},
 		showGrid () {
-			return this.scrollParentWidth > 710 && this.format !== 'list' // if we can't fit two rooms together, switch to list
+			// return this.scrollParentWidth > 710 && this.format !== 'list' // if we can't fit two rooms together, switch to list
+			return false
 		},
 		roomsLookup () {
 			if (!this.schedule) return {}

--- a/src/App.vue
+++ b/src/App.vue
@@ -118,8 +118,7 @@ export default {
 			return this.schedule ? Math.min(this.scrollParentWidth, 78 + this.schedule.rooms.length * 650) : this.scrollParentWidth
 		},
 		showGrid () {
-			// return this.scrollParentWidth > 710 && this.format !== 'list' // if we can't fit two rooms together, switch to list
-			return false
+			return this.scrollParentWidth > 710 && this.format !== 'list' // if we can't fit two rooms together, switch to list
 		},
 		roomsLookup () {
 			if (!this.schedule) return {}

--- a/src/components/Session.vue
+++ b/src/components/Session.vue
@@ -24,7 +24,6 @@ a.c-linear-schedule-session(:class="{faved}", :style="style", :href="link", @cli
 			.track(v-if="session.track") {{ getLocalizedString(session.track.name) }}
 			.room(v-if="showRoom && session.room") {{ getLocalizedString(session.room.name) }}
 
-	.fav-count(v-if="session.fav_count > 0") {{ session.fav_count > 99 ? "99+" : session.fav_count  }}
 	bunt-icon-button.btn-fav-container(@click.prevent.stop="faved ? $emit('unfav', session.id) : $emit('fav', session.id)")
 		svg.star(viewBox="0 0 24 24")
 			path(d="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z")


### PR DESCRIPTION
this PR related to issue https://github.com/fossasia/eventyay-talk/issues/155

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Removed the number icon indicating popularity from the schedule calendar view in both the main application and session components.

<!-- Generated by sourcery-ai[bot]: end summary -->