### PR TITLE
Add tags to public schedule and session view

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -151,7 +151,8 @@ export default {
 					track: this.tracksLookup[session.track],
 					room: this.roomsLookup[session.room],
 					fav_count: session.fav_count,
-					do_not_record: session.do_not_record
+					do_not_record: session.do_not_record,
+					tags: session.tags
 				})
 			}
 			sessions.sort((a, b) => a.start.diff(b.start))

--- a/src/components/Session.vue
+++ b/src/components/Session.vue
@@ -23,6 +23,9 @@ a.c-linear-schedule-session(:class="{faved}", :style="style", :href="link", @cli
 		.bottom-info
 			.track(v-if="session.track") {{ getLocalizedString(session.track.name) }}
 			.room(v-if="showRoom && session.room") {{ getLocalizedString(session.room.name) }}
+		.tags-box
+			.tags(v-for="tag_item of session.tags")
+				.tag-item(:style="{'background-color': tag_item.color, 'color': getContrastColor(tag_item.color)}") {{ tag_item.tag }}
 
 	bunt-icon-button.btn-fav-container(@click.prevent.stop="faved ? $emit('unfav', session.id) : $emit('fav', session.id)")
 		svg.star(viewBox="0 0 24 24")
@@ -110,6 +113,27 @@ export default {
 			} catch (error) {
 				return this.session.abstract
 			}
+		}
+	},
+	methods: {
+		getContrastColor(bgColor) {
+			if (!bgColor) {
+				return '';
+			}
+
+			// Remove the hash if it's there
+			bgColor = bgColor.replace('#', '');
+
+			// Convert the color to RGB
+			var r = parseInt(bgColor.slice(0, 2), 16);
+			var g = parseInt(bgColor.slice(2, 4), 16);
+			var b = parseInt(bgColor.slice(4, 6), 16);
+
+			// Calculate the brightness of the color
+			var brightness = (r * 299 + g * 587 + b * 114) / 1000;
+
+			// If the brightness is over 128, return black. Otherwise, return white
+			return brightness > 128 ? 'black' : 'white';
 		}
 	}
 }
@@ -255,4 +279,11 @@ export default {
 
 	.do_not_record
 		margin: 10px 0px
+	.tags-box
+		display: flex
+		margin: 5px 0px
+		.tags
+			margin: 0px 2px
+			.tag-item
+				padding: 3px
 </style>

--- a/src/components/Session.vue
+++ b/src/components/Session.vue
@@ -19,13 +19,13 @@ a.c-linear-schedule-session(:class="{faved}", :style="style", :href="link", @cli
 				path(d="M1.29292 20.2929C0.902398 20.6834 0.902398 21.3166 1.29292 21.7071C1.68345 22.0976 2.31661 22.0976 2.70714 21.7071L22.7071 1.70711C23.0977 1.31658 23.0977 0.68342 22.7071 0.29289C22.3166 -0.097631 21.6834 -0.097631 21.2929 0.29289L20.2975 1.28829C20.296 1.28982 20.2944 1.29135 20.2929 1.29289L2.29289 19.2929C2.29136 19.2944 2.28984 19.296 2.28832 19.2975L1.29292 20.2929z", fill="#758CA3")
 				path(d="M15 3C15.2339 3 15.4615 3.02676 15.68 3.07739L13.7574 5H3C2.44772 5 2 5.44771 2 6V16C2 16.2142 2.06734 16.4126 2.182 16.5754L0.87868 17.8787C0.839067 17.9183 0.800794 17.9587 0.76386 18C0.28884 17.4692 0 16.7683 0 16V6C0 4.34314 1.34315 3 3 3H15z", fill="#758CA3")
 				path(d="M10.2426 17H15C15.5523 17 16 16.5523 16 16V14.0233C15.9996 14.0079 15.9996 13.9924 16 13.9769V11.2426L18 9.2426V13.2792L22 14.6126V7.38742L18.7828 8.45982L21.9451 5.29754L22.6838 5.05132C23.3313 4.83547 24 5.31744 24 6V16C24 16.6826 23.3313 17.1645 22.6838 16.9487L18 15.3874V16C18 17.6569 16.6569 19 15 19H8.24264L10.2426 17z", fill="#758CA3")
+		.tags-box
+			.tags(v-for="tag_item of session.tags")
+				.tag-item(:style="{'background-color': tag_item.color, 'color': getContrastColor(tag_item.color)}") {{ tag_item.tag }}
 		.abstract(v-if="showAbstract", v-html="abstract")
 		.bottom-info
 			.track(v-if="session.track") {{ getLocalizedString(session.track.name) }}
 			.room(v-if="showRoom && session.room") {{ getLocalizedString(session.room.name) }}
-		.tags-box
-			.tags(v-for="tag_item of session.tags")
-				.tag-item(:style="{'background-color': tag_item.color, 'color': getContrastColor(tag_item.color)}") {{ tag_item.tag }}
 
 	bunt-icon-button.btn-fav-container(@click.prevent.stop="faved ? $emit('unfav', session.id) : $emit('fav', session.id)")
 		svg.star(viewBox="0 0 24 24")


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/87abf823-48c6-4cf1-b2d1-594daa25b0e7)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request adds a feature to display tags in the session view, with each tag styled according to its background color and a calculated contrast color for the text. Additionally, a method to determine the appropriate text color based on the tag's background color brightness has been implemented.

- **New Features**:
    - Added tags display to the session view, showing tags with background and text color based on tag properties.
- **Enhancements**:
    - Introduced a method to calculate contrast color for tag backgrounds to ensure text readability.

<!-- Generated by sourcery-ai[bot]: end summary -->