### PR TITLE
Re-enable favs count in session list view

### DIFF
--- a/src/components/LinearSchedule.vue
+++ b/src/components/LinearSchedule.vue
@@ -10,7 +10,8 @@
 					:session="session",
 					:faved="session.id && favs.includes(session.id)",
 					@fav="$emit('fav', session.id)",
-					@unfav="$emit('unfav', session.id)"
+					@unfav="$emit('unfav', session.id)",
+					isLinearSchedule=true
 				)
 				.break(v-else)
 					.title {{ getLocalizedString(session.title) }}

--- a/src/components/Session.vue
+++ b/src/components/Session.vue
@@ -26,7 +26,7 @@ a.c-linear-schedule-session(:class="{faved}", :style="style", :href="link", @cli
 		.bottom-info
 			.track(v-if="session.track") {{ getLocalizedString(session.track.name) }}
 			.room(v-if="showRoom && session.room") {{ getLocalizedString(session.room.name) }}
-
+		.fav-count(v-if="session.fav_count > 0 && isLinearSchedule") {{ session.fav_count > 99 ? "99+" : session.fav_count  }}
 	bunt-icon-button.btn-fav-container(@click.prevent.stop="faved ? $emit('unfav', session.id) : $emit('fav', session.id)")
 		svg.star(viewBox="0 0 24 24")
 			path(d="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z")
@@ -60,7 +60,8 @@ export default {
 		hasAmPm: {
 			type: Boolean,
 			default: false
-		}
+		},
+		isLinearSchedule: Boolean
 	},
 	inject: {
 		eventUrl: { default: null },


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request re-enables the display of favorite counts in the session list view for linear schedules by adding a condition to show the favorite count if it is greater than zero.

- **Enhancements**:
    - Re-enabled the display of favorite counts in the session list view for linear schedules.

<!-- Generated by sourcery-ai[bot]: end summary -->