### PR TITLE
Fix: Calendar cause redundant window horizontal scroll

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -483,7 +483,6 @@ export default {
 	height: 100%
 	font-size: 14px
 	&.grid-schedule
-		min-width: min-content
 		max-width: var(--schedule-max-width)
 		margin: 0 auto
 	&.list-schedule


### PR DESCRIPTION
Related https://github.com/fossasia/eventyay-talk/issues/380

## Summary by Sourcery

Bug Fixes:
- Remove min-width: min-content on .grid-schedule to eliminate redundant horizontal scroll