### PR TITLE
feat: add disable-auto-scroll prop to prevent auto-scroll on sessions page 

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -31,6 +31,7 @@
 			:scrollParent="scrollParent",
 			:favs="favs",
 			:onHomeServer="onHomeServer",
+			:disableAutoScroll="disableAutoScroll",
 			@changeDay="setCurrentDay($event)",
 			@fav="fav($event)",
 			@unfav="unfav($event)")
@@ -45,6 +46,7 @@
 			:scrollParent="scrollParent",
 			:favs="favs",
 			:onHomeServer="onHomeServer",
+			:disableAutoScroll="disableAutoScroll",
 			@changeDay="setCurrentDay($event)",
 			@fav="fav($event)",
 			@unfav="unfav($event)")
@@ -111,6 +113,11 @@ export default {
 		dateFilter: {
 			type: String,
 			default: ''
+		},
+		// Disable auto-scroll to current time on page load
+		disableAutoScroll: {
+			type: Boolean,
+			default: false
 		}
 	},
 	provide () {

--- a/src/components/GridSchedule.vue
+++ b/src/components/GridSchedule.vue
@@ -67,7 +67,8 @@ export default {
 		locale: String,
 		hasAmPm: Boolean,
 		scrollParent: Element,
-		onHomeServer: Boolean
+		onHomeServer: Boolean,
+		disableAutoScroll: Boolean
 	},
 	data () {
 		return {
@@ -266,6 +267,8 @@ export default {
 			}
 		}
 		if (fragmentIsDate || !this.$refs.now) return
+		// Skip auto-scroll if disabled via prop
+		if (this.disableAutoScroll) return
 		const scrollTop = this.$refs.now.offsetTop + this.getOffsetTop()
 		if (this.scrollParent) {
 			this.scrollParent.scrollTop = scrollTop

--- a/src/components/GridScheduleWrapper.vue
+++ b/src/components/GridScheduleWrapper.vue
@@ -13,6 +13,7 @@
 		:scrollParent="scrollParent",
 		:favs="favs",
 		:onHomeServer="onHomeServer",
+		:disableAutoScroll="disableAutoScroll",
 		@changeDay="$emit('changeDay', $event)",
 		@fav="$emit('fav', $event)",
 		@unfav="$emit('unfav', $event)"
@@ -40,7 +41,8 @@ export default {
 		locale: String,
 		hasAmPm: Boolean,
 		scrollParent: Element,
-		onHomeServer: Boolean
+		onHomeServer: Boolean,
+		disableAutoScroll: Boolean
 	},
 	computed: {
 		gridGroups () {

--- a/src/components/LinearSchedule.vue
+++ b/src/components/LinearSchedule.vue
@@ -42,7 +42,8 @@ export default {
 		currentDay: String,
 		now: Object,
 		scrollParent: Element,
-		onHomeServer: Boolean
+		onHomeServer: Boolean,
+		disableAutoScroll: Boolean
 	},
 	data () {
 		return {
@@ -103,6 +104,8 @@ export default {
 			}
 		}
 		if (fragmentIsDate) return
+		// Skip auto-scroll if disabled via prop
+		if (this.disableAutoScroll) return
 		const nowIndex = this.sessionBuckets.findIndex(bucket => this.now < bucket.date)
 		// do not scroll if the event has not started yet
 		if (nowIndex < 0) return


### PR DESCRIPTION
## Summary by Sourcery

Add a configurable option to disable automatic scrolling to the current time on the sessions page and propagate it through schedule components.

New Features:
- Introduce a disableAutoScroll prop on the root App component to control auto-scrolling behavior on the sessions view.
- Add disableAutoScroll support to GridSchedule, LinearSchedule, and GridScheduleWrapper components to respect the setting and skip auto-scroll when enabled.