### PR TITLE
fix(timezone): Add other timezone options with `local` and `event` indicators

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -74,8 +74,6 @@
 		@fav="fav($event)",
 		@unfav="unfav($event)"
 	)
-	a(href="https://pretalx.com", target="_blank", v-if="!onHomeServer").powered-by powered by
-		span.pretalx(href="https://pretalx.com", target="_blank") pretalx
 </template>
 <script>
 import { computed } from 'vue'


### PR DESCRIPTION
This PR adds option to select **other timezones** and adds `local` and `event` indicators.
>This PR also removes the "Powered by" to match the changes made earlier in eventyay.

This version is built and is included in https://github.com/fossasia/eventyay/pull/1623 ([here](https://github.com/fossasia/eventyay/pull/1623/changes#diff-113cf19bf045c47dfd0f241f247decdab155705ad83ebf5348c44d0d2df9bf03))

**Modified timezone dropdown:**
<img width="251" height="481" alt="image" src="https://github.com/user-attachments/assets/55b1b8cc-a349-41aa-842b-d32431fbbcd0" />

## Summary by Sourcery

Update schedule timezone selection to support pinned local/event timezones and an extended list of other timezones, and remove external "powered by" branding from the app footer.

New Features:
- Allow selecting from a comprehensive list of other timezones in the schedule settings dropdown.
- Highlight local and event timezones as pinned options with clear labels in the timezone selector.

Enhancements:
- Improve timezone selector UX with pinned options, custom labels, and visual grouping between pinned and other timezones.

Chores:
- Remove pretalx "powered by" footer branding to align with upstream eventyay changes.